### PR TITLE
Restore previous methods and update logic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem "fastlane", :path => "/Users/dana_dramowicz/code/fastlane-fork"
+gem 'fastlane', :git => 'https://github.com/Xjkstar/fastlane.git', ref: 'c2fbed42dbc8c4949d7080393662d59221e30491' 
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'fastlane', :git => 'https://github.com/Xjkstar/fastlane/tree/master'
+gem "fastlane", :path => "/Users/dana_dramowicz/code/fastlane-fork"
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/lib/fastlane/plugin/clean_testflight_testers/actions/clean_testflight_testers_action.rb
+++ b/lib/fastlane/plugin/clean_testflight_testers/actions/clean_testflight_testers_action.rb
@@ -25,39 +25,37 @@ module Fastlane
           tester_metrics = current_tester.beta_tester_metrics.first
           installed_bundle_version = current_tester.installedCfBundleVersion
 
-          if tester_metrics 
-          # first, remove all users who didn't install a build  (not all users have the last_modified_dateb or even tester_metrics)
-          if tester_metrics.last_modified_date 
+          if tester_metrics
+            # First, remove all users who didn't install a build 
+            if tester_metrics.last_modified_date
               time = Time.parse(tester_metrics.last_modified_date)
               days_since_status_change = (Time.now - time) / 60.0 / 60.0 / 24.0
 
-          if tester_metrics.beta_tester_state == "INVITED"
-            if days_since_status_change > params[:days_of_inactivity]
-              remove_tester(current_tester, spaceship_app, params[:dry_run]) # user got invited, but never installed a build... why would you do that?
-              counter += 1
-            end
-            next
-
-          # then, remove all users who have had no sessions within the given `days of inactivity`
-          elsif tester_metrics.session_count && tester_metrics.session_count == 0
-            # We don't really have a good way to detect whether the user is active unfortunately
-            # So we can just delete users that had no sessions
-            if days_since_status_change > params[:days_of_inactivity] 
-              # User had no sessions in the last e.g. 30 days, let's get rid of them
-              remove_tester(current_tester, spaceship_app, params[:dry_run])
-              counter += 1
-            end
-            next
-          end
-        end
-
-          # lastly, if they are still there, and didn't have any tester metrics, make sure they have an up-to-date build
-            if installed_bundle_version.to_i > 0 && installed_bundle_version.to_i < oldestBuildNumber
-            UI.message("TestFlight tester #{current_tester} has version #{installed_bundle_version} installed and should be removed")
-            remove_tester(current_tester, spaceship_app, params[:dry_run]) # user has an old build installed, let's remove
-            counter += 1
+              if tester_metrics.beta_tester_state == "INVITED"
+                if days_since_status_change > params[:days_of_inactivity]
+                  remove_tester(current_tester, spaceship_app, params[:dry_run]) # User got invited, but never installed a build
+                  counter += 1
+                end
+                next
+              # Then, remove all users who have had no sessions within the given `days of inactivity`
+              elsif tester_metrics.session_count && tester_metrics.session_count == 0
+                if days_since_status_change > params[:days_of_inactivity]
+                  # User had no sessions in the last e.g. 30 days, let's get rid of them
+                  remove_tester(current_tester, spaceship_app, params[:dry_run])
+                  counter += 1
+                end
+                next
               end
-            next
+            end
+          end
+
+          # Lastly, if they are still there, and didn't have any tester metrics, make sure they have an up-to-date build
+          if installed_bundle_version.to_i > 0 && installed_bundle_version.to_i < oldestBuildNumber
+            UI.message("TestFlight tester #{current_tester} has version #{installed_bundle_version} installed and should be removed")
+            remove_tester(current_tester, spaceship_app, params[:dry_run]) # User has an old build installed, let's remove
+            counter += 1
+          end
+          next
         end
 
         if params[:dry_run]
@@ -65,7 +63,8 @@ module Fastlane
         else
           UI.success("Successfully removed #{counter} testers 🦋")
         end
-      end
+        end
+
 
       def self.remove_tester(tester, app, dry_run)
         if dry_run

--- a/lib/fastlane/plugin/clean_testflight_testers/actions/clean_testflight_testers_action.rb
+++ b/lib/fastlane/plugin/clean_testflight_testers/actions/clean_testflight_testers_action.rb
@@ -25,6 +25,7 @@ module Fastlane
           tester_metrics = current_tester.beta_tester_metrics.first
           installed_bundle_version = current_tester.installedCfBundleVersion
 
+          if tester_metrics 
           # first, remove all users who didn't install a build  (not all users have the last_modified_dateb or even tester_metrics)
           if tester_metrics.last_modified_date 
               time = Time.parse(tester_metrics.last_modified_date)
@@ -38,18 +39,19 @@ module Fastlane
             next
 
           # then, remove all users who have had no sessions within the given `days of inactivity`
-          elsif tester_metrics.session_count
+          elsif tester_metrics.session_count && tester_metrics.session_count == 0
             # We don't really have a good way to detect whether the user is active unfortunately
             # So we can just delete users that had no sessions
-            if days_since_status_change > params[:days_of_inactivity] && tester_metrics.session_count == 0
+            if days_since_status_change > params[:days_of_inactivity] 
               # User had no sessions in the last e.g. 30 days, let's get rid of them
               remove_tester(current_tester, spaceship_app, params[:dry_run])
               counter += 1
             end
             next
           end
+        end
 
-          # lastly, if they are still there, make sure they have an up-to-date build
+          # lastly, if they are still there, and didn't have any tester metrics, make sure they have an up-to-date build
             if installed_bundle_version.to_i > 0 && installed_bundle_version.to_i < oldestBuildNumber
             UI.message("TestFlight tester #{current_tester} has version #{installed_bundle_version} installed and should be removed")
             remove_tester(current_tester, spaceship_app, params[:dry_run]) # user has an old build installed, let's remove

--- a/lib/fastlane/plugin/clean_testflight_testers/actions/clean_testflight_testers_action.rb
+++ b/lib/fastlane/plugin/clean_testflight_testers/actions/clean_testflight_testers_action.rb
@@ -8,9 +8,9 @@ module Fastlane
         username = params[:username]
         oldestBuildNumber = params[:oldest_build_allowed].to_i
 
-        UI.message("Login to iTunes Connect (#{username})")
-        Spaceship::Tunes.login(username)
-        Spaceship::Tunes.select_team
+        UI.message("Login to ASC API (#{username})")
+        Spaceship::ConnectAPI.login(username)
+        Spaceship::ConnectAPI.select_team
         UI.message("Login successful")
 
         UI.message("Fetching all TestFlight testers, this might take a few minutes, depending on the number of testers")
@@ -25,38 +25,39 @@ module Fastlane
           tester_metrics = current_tester.beta_tester_metrics.first
           installed_bundle_version = current_tester.installedCfBundleVersion
 
-          # Since version 2.4 of the App Store Connect API, beta tester metrics are not available in the same way - this step allows us to remove testers who have older builds installed
-          if tester_metrics.nil?
+
+# then, remove all users who have had no sessions in the last 30 days
+# lastly, if they are still there, make sure they have an up-to-date build
+          if tester_metrics.last_modified_date # first, remove all users who didn't install a build  (not all users have the last_modified_date or even tester_metrics)
+              time = Time.parse(tester_metrics.last_modified_date)
+              days_since_status_change = (Time.now - time) / 60.0 / 60.0 / 24.0
+
+          if tester_metrics.beta_tester_state == "INVITED"
+            if days_since_status_change > params[:days_of_inactivity]
+              remove_tester(current_tester, spaceship_app, params[:dry_run]) # user got invited, but never installed a build... why would you do that?
+              counter += 1
+            end
+            next
+          elsif tester_metrics.session_count
+            # We don't really have a good way to detect whether the user is active unfortunately
+            # So we can just delete users that had no sessions
+            if days_since_status_change > params[:days_of_inactivity] && tester_metrics.session_count == 0
+              # User had no sessions in the last e.g. 30 days, let's get rid of them
+              remove_tester(current_tester, spaceship_app, params[:dry_run])
+              counter += 1
+            end
+            next
+          end
+
+          # lastly, if they are still there, make sure they have an up-to-date build
             if installed_bundle_version.to_i > 0 && installed_bundle_version.to_i < oldestBuildNumber
             UI.message("TestFlight tester #{current_tester} has version #{installed_bundle_version} installed and should be removed")
             remove_tester(current_tester, spaceship_app, params[:dry_run]) # user has an old build installed, let's remove
             counter += 1
               end
             next
-          end
-        end  
-          # time = Time.parse(tester_metrics.last_modified_date)
-          # days_since_status_change = (Time.now - time) / 60.0 / 60.0 / 24.0
-
-        #   if tester_metrics.beta_tester_state == "INVITED"
-        #     if days_since_status_change > params[:days_of_inactivity]
-        #       remove_tester(current_tester, spaceship_app, params[:dry_run]) # user got invited, but never installed a build... why would you do that?
-        #       counter += 1
-        #     end
-        #   else
-        #     # We don't really have a good way to detect whether the user is active unfortunately
-        #     # So we can just delete users that had no sessions
-        #     if days_since_status_change > params[:days_of_inactivity] && tester_metrics.session_count == 0
-        #       # User had no sessions in the last e.g. 30 days, let's get rid of them
-        #       remove_tester(current_tester, spaceship_app, params[:dry_run])
-        #       counter += 1
-        #     elsif params[:oldest_build_allowed] && tester_metrics.installed_cf_bundle_version.to_i > 0 && tester_metrics.installed_cf_bundle_version.to_i < params[:oldest_build_allowed]
-        #       # User has a build that is too old, let's get rid of them
-        #       remove_tester(current_tester, spaceship_app, params[:dry_run])
-        #       counter += 1
-        #     end
-        #   end
-        # end
+        
+        end
 
         if params[:dry_run]
           UI.success("Didn't delete any testers, but instead only printed them out (#{counter}) disable `dry_run` to actually delete them 🦋")
@@ -94,7 +95,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :username,
                                      short_option: "-u",
                                      env_name: "CLEAN_TESTFLIGHT_TESTERS_USERNAME",
-                                     description: "Your Apple ID Username",
+                                     description: "Your Apple ID Username - Test",
                                      default_value: user),
           FastlaneCore::ConfigItem.new(key: :app_identifier,
                                        short_option: "-a",

--- a/lib/fastlane/plugin/clean_testflight_testers/actions/clean_testflight_testers_action.rb
+++ b/lib/fastlane/plugin/clean_testflight_testers/actions/clean_testflight_testers_action.rb
@@ -25,10 +25,8 @@ module Fastlane
           tester_metrics = current_tester.beta_tester_metrics.first
           installed_bundle_version = current_tester.installedCfBundleVersion
 
-
-# then, remove all users who have had no sessions in the last 30 days
-# lastly, if they are still there, make sure they have an up-to-date build
-          if tester_metrics.last_modified_date # first, remove all users who didn't install a build  (not all users have the last_modified_date or even tester_metrics)
+          # first, remove all users who didn't install a build  (not all users have the last_modified_dateb or even tester_metrics)
+          if tester_metrics.last_modified_date 
               time = Time.parse(tester_metrics.last_modified_date)
               days_since_status_change = (Time.now - time) / 60.0 / 60.0 / 24.0
 
@@ -38,6 +36,8 @@ module Fastlane
               counter += 1
             end
             next
+
+          # then, remove all users who have had no sessions within the given `days of inactivity`
           elsif tester_metrics.session_count
             # We don't really have a good way to detect whether the user is active unfortunately
             # So we can just delete users that had no sessions
@@ -56,7 +56,6 @@ module Fastlane
             counter += 1
               end
             next
-        
         end
 
         if params[:dry_run]

--- a/lib/fastlane/plugin/clean_testflight_testers/actions/clean_testflight_testers_action.rb
+++ b/lib/fastlane/plugin/clean_testflight_testers/actions/clean_testflight_testers_action.rb
@@ -7,6 +7,7 @@ module Fastlane
         app_identifier = params[:app_identifier]
         username = params[:username]
         oldestBuildNumber = params[:oldest_build_allowed].to_i
+        days_of_inactivity = params[:days_of_inactivity]
 
         UI.message("Login to ASC API (#{username})")
         Spaceship::ConnectAPI.login(username)
@@ -31,13 +32,13 @@ module Fastlane
             days_since_status_change = (Time.now - time) / 60.0 / 60.0 / 24.0
 
             # User got invited, but never installed a build
-            if tester_metrics.beta_tester_state == "INVITED" && days_since_status_change > params[:days_of_inactivity]
+            if tester_metrics.beta_tester_state == "INVITED" && days_since_status_change > days_of_inactivity
               remove_tester(current_tester, spaceship_app, params[:dry_run], "never installed a build") 
               counter += 1
               next
-            elsif tester_metrics.session_count && tester_metrics.session_count == 0 && days_since_status_change > params[:days_of_inactivity]
-              # User had no sessions in the last e.g. 30 days, let's get rid of them
-              remove_tester(current_tester, spaceship_app, params[:dry_run], "didn't have any active sessions in the given period")
+            elsif tester_metrics.session_count && tester_metrics.session_count == 0 && days_since_status_change > days_of_inactivity
+              # User had no sessions in the last 60 days, let's get rid of them
+              remove_tester(current_tester, spaceship_app, params[:dry_run], "didn't have any active sessions in the last #{days_of_inactivity} days")
               counter += 1
               next
             end


### PR DESCRIPTION
This PR proposes the following changes:

1. Restores previously commented out methods for cleaning up stale users. I noticed in my testing that actually a lot of users do have the `tester_metrics` available (perhaps a temporary issue, before?), so we can take advantage of that to remove users who haven't had any active sessions in the given time period. I also restored old logic for checking whether a user is in a `INVITED` state, but... I haven't seen any evidence of the ASC API returning any type of state that is not `INSTALLED` or `ACCEPTED`. Even users listed as "Deleted" on the ASC website, return an `INSTALLED` state here for some reason 🤷 so we could definitely see already-deleted users cropping up in this script, and getting removed again. There's no downside to this other than the fact that the tool could tell us that it deleted x number of testers, but it actually removed far fewer (since some of them are already in that Deleted state). 
2. Updated the logic that compares the user's installed version with the `oldest_build_allowed` regardless of whether they have tester metrics available.
3. Added a parameter to the logging to display why a user is eligible for removal.
4. Updated the `Gemfile` to point to a specific commit (the latest one) in the forked repo.
5. Changed to use the `ConnectAPI`. It seems to have no effect as a user, but it looks like Fastlane allows the usage of API keys with that service, which we may want to do in the future, if running this tool from CI.


This can be tested by checking out this branch of ios-live https://github.com/guardian/ios-live/pull/8142, and then changing the `Pluginfile` in `GLA/BetaTesterManagement` to point to this branch i.e.

`gem 'fastlane-plugin-clean_testflight_testers', git: 'https://github.com/aoifemcl15/fastlane-plugin-clean_testflight_testers',  branch: 'feat/update-API-usage'`

I think you'll need to run `bundle install` in the `GLA/BetaTesterManagment` directory after you've made this change as well.