### PR TITLE
Handle delete attempts for unavailable users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'fastlane', :git => 'https://github.com/Xjkstar/fastlane.git', ref: 'c2fbed42dbc8c4949d7080393662d59221e30491' 
+gem 'fastlane', :path => '/Users/dana_dramowicz/code/fastlane-fork' 
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'fastlane', :path => '/Users/dana_dramowicz/code/fastlane-fork' 
+gem 'fastlane', :git => 'https://github.com/Xjkstar/fastlane.git', ref: 'c2fbed42dbc8c4949d7080393662d59221e30491' 
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/lib/fastlane/plugin/clean_testflight_testers/actions/clean_testflight_testers_action.rb
+++ b/lib/fastlane/plugin/clean_testflight_testers/actions/clean_testflight_testers_action.rb
@@ -65,7 +65,16 @@ module Fastlane
           UI.message("TestFlight tester #{tester.email} for app ID #{app.id} should be removed because they #{reason}")
         else
           UI.message("Removing tester #{tester.email} for app ID #{app.id} because they #{reason}")
-          tester.delete_from_apps(apps: [app])
+          begin
+            tester.delete_from_apps(apps: [app])
+          rescue Spaceship::UnexpectedResponse => e
+            if e.message.include?("The specified resource does not exist")
+              UI.message("Ignoring 404 error: #{e.message}")
+              # Some testers (presumambly those who are already in a Deleted state) will return a 404. This skips these users.
+            else
+              raise # Reraise if it's not a 404-related error
+            end
+          end
         end
       end
 


### PR DESCRIPTION
While attempting to run the beta testing tool, I noticed an issue where, when `dry_run` was set to `false` (and the tool was actually trying to delete users), there were some cases were the API would return a 404 with `The specified resource does not exist - There is no resource of type 'betaTesters' with id ...`.  I assume this is because some users in a Deleted state don't exist anymore, so cannot be Deleted again. 

As soon as a single 404 response would be returned, the entire process would fall over.

I've added some logic to our plugin to skip over any "The specified resource does not exist" responses. 